### PR TITLE
chore(): use node 11.0.0 and yarn 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
 
 ENV NPM_CONFIG_LOGLEVEL info
 # using current Node version
-ENV NODE_VERSION 10.4.0
+ENV NODE_VERSION 11.0.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -46,7 +46,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.7.0
+ENV YARN_VERSION 1.12.1
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
Fixes yarn warning:
`warning Your current version of Yarn is out of date. The latest version is "1.10.1", while you're on "1.7.0".                                                                                                                                                                                                                                                                                                                                                                                                    `